### PR TITLE
Fix ReferenceError in jesFtp.disconnect() error handler

### DIFF
--- a/app/utils/jesFtp.js
+++ b/app/utils/jesFtp.js
@@ -66,7 +66,7 @@ class JES {
     console.log("Attempting to disconnect");
     this.ftp.end()
       .then((msg) => console.log(msg))
-      .catch(err => _errorLookup(err))
+      .catch(err => this._errorLookup(err))
     // .then(async () => {
     this.connectionStatus = this.ftp.getConnectionStatus();
     console.log("Connection Status: ", this.connectionStatus);


### PR DESCRIPTION
## What

Fixes a `ReferenceError` in `JES.disconnect()`'s FTP error handler.

[`app/utils/jesFtp.js`](app/utils/jesFtp.js#L69) called a bare `_errorLookup(err)` inside the `.catch` of `this.ftp.end()`. `_errorLookup` is a class method, so the correct reference is `this._errorLookup`. As written, if `ftp.end()` rejects, the catch callback throws `ReferenceError: _errorLookup is not defined` instead of handling the error — leaving the connection-status indicators stuck and producing an unhandled promise rejection.

This path is reachable from the **INTERRUPT** button (`StatusBar`) and the **Help → Kill FTP** menu item.

Every other `.catch` in the file already uses `this._errorLookup(err)` (e.g. `connect()` at line 57); `disconnect()` was the lone exception.

## Change

```diff
-      .catch(err => _errorLookup(err))
+      .catch(err => this._errorLookup(err))
```

## Verification

ESLint `no-undef` flagged the original line:

```
69:21  error  '_errorLookup' is not defined  no-undef
```

After the fix that error is gone. (The remaining `no-undef` errors ESLint reports are in the never-called `_pollMostRecentJobUntilComplete` dead method — a separate issue, intentionally out of scope here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
