### PR TITLE
fix: serialize FTP operations and make listDatasets atomic (closes #2)

### DIFF
--- a/app/keypunch.d.ts
+++ b/app/keypunch.d.ts
@@ -41,6 +41,9 @@ export type MenuChannel =
 // The JES/FTP slice of the API. Each call does the FULL FTP command chain in
 // main and returns RAW results (LIST -> string[], RETR -> string) or rejects;
 // parsing happens in the renderer (app/utils/jesParse.ts).
+//
+// All calls are serialized through a single queue in main so FTP commands
+// from concurrent renderer actions never interleave on the shared connection.
 export interface KeypunchJesApi {
   connect(config: FtpConfig): Promise<string>;
   disconnect(): Promise<string>;
@@ -51,6 +54,15 @@ export interface KeypunchJesApi {
   listDatasets(config: FtpConfig): Promise<string[]>;
   listMembers(config: FtpConfig, dsname: string): Promise<string[]>;
   retrieveMember(config: FtpConfig, dsname: string, member: string): Promise<string>;
+  /**
+   * Atomic compound operation: lists all datasets and all their members in a
+   * single IPC call so concurrent operations (e.g. pollJobStatus) cannot
+   * interleave FTP commands between individual listMembers calls.
+   */
+  listDatasetsWithMembers(config: FtpConfig): Promise<{
+    datasetRows: string[];
+    memberRowsByDs: Record<string, string[]>;
+  }>;
 }
 
 // The full `window.keypunch` surface.

--- a/app/utils/jesFtp.ts
+++ b/app/utils/jesFtp.ts
@@ -153,23 +153,19 @@ class JES {
     store.dispatch(setIsRetrieving(true));
     store.dispatch(setIsConnecting(true));
     try {
-      const config = getConfig();
-      const rows = await bridge().listDatasets(config);
+      // Use the compound call so the full dataset + member listing is a single
+      // atomic operation in the main-process FTP queue.  A concurrent
+      // pollJobStatus can no longer interleave its FTP commands between the
+      // individual member-listing calls (fixes issue #2).
+      const { datasetRows, memberRowsByDs } = await bridge().listDatasetsWithMembers(getConfig());
       store.dispatch(setIsConnecting(false));
       store.dispatch(setIsConnected(true));
       // parseDatasets throws on an unreadable listing and drops the header row.
-      const datasets = parseDatasets(rows);
-      // Populate the members of each dataset, exactly as the old flow did.
+      const datasets = parseDatasets(datasetRows);
       for (const dataset of datasets) {
         const dsname = dataset.attributes.dsname;
-        try {
-          const memberRows = await bridge().listMembers(config, dsname);
-          const members = parseMembers(memberRows, dsname);
-          dataset.children.push(...members);
-        } catch (err) {
-          // An empty / unreadable PDS just yields no members.
-          console.log(err);
-        }
+        const memberRows = memberRowsByDs[dsname] ?? [];
+        dataset.children.push(...parseMembers(memberRows, dsname));
       }
       store.dispatch(refreshDatasets(datasets));
       store.dispatch(setIsRetrieved(true));

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -36,6 +36,13 @@ let mainWindow: BrowserWindow | null = null;
 // renderer used to run inline, and returns RAW results (LIST -> string[],
 // RETR -> string) or throws. Parsing stays in the renderer (jesParse.ts) so
 // the harness unit/integration tests remain valid.
+//
+// All public methods are called through the serial IPC queue (see
+// registerIpc below), so only one FTP operation runs at a time and their
+// commands can never interleave on the shared PromiseFtp connection.
+// Internal helpers (_ensureConnected, _setEncoding, _setFiletype) are
+// private and must NOT be wrapped in the queue themselves — they are only
+// called from within already-queued operations.
 // --------------------------------------------------------------------------
 class JES {
   private ftp: PromiseFtp;
@@ -44,16 +51,56 @@ class JES {
     this.ftp = new PromiseFtp();
   }
 
-  async connect(config: FtpConfig): Promise<string> {
-    if (this.ftp.getConnectionStatus() === 'connected') {
-      return 'Already connected';
-    }
+  // -----------------------------------------------------------------------
+  // Private helpers — called only from within queued public methods.
+  // -----------------------------------------------------------------------
+
+  private async _ensureConnected(config: FtpConfig): Promise<void> {
+    if (this.ftp.getConnectionStatus() === 'connected') return;
     await this.ftp.connect({
       host: config.hostName,
       port: config.ftpPort,
       user: config.ftpUserName,
       password: config.ftpPassword
     });
+  }
+
+  private async _setEncoding(type: string): Promise<void> {
+    if (type === 'ascii') await this.ftp.ascii();
+  }
+
+  private async _setFiletype(filetype: string): Promise<void> {
+    if (filetype === 'jes' || filetype === 'seq') {
+      await this.ftp.site('FILETYPE=' + filetype);
+    }
+  }
+
+  private _streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+    return new Promise((resolve, reject) => {
+      let data = '';
+      stream.on('data', (chunk: Buffer | string) => { data += chunk.toString(); });
+      stream.on('end', () => resolve(data));
+      stream.on('error', reject);
+      // CRITICAL: node-ftp hands back a PAUSED data socket. On modern Node,
+      // attaching a 'data' listener to an explicitly-paused stream does NOT
+      // auto-resume it, so without this call the stream never flows and the
+      // transfer hangs forever. This is the latent bug from issue #16.
+      stream.resume();
+    });
+  }
+
+  private _sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  // -----------------------------------------------------------------------
+  // Public methods — each runs one atomic sequence of FTP commands.
+  // Called through the serial queue in registerIpc(); never call these
+  // from within another public method (use the private helpers instead).
+  // -----------------------------------------------------------------------
+
+  async connect(config: FtpConfig): Promise<string> {
+    await this._ensureConnected(config);
     return 'connected';
   }
 
@@ -83,65 +130,53 @@ class JES {
     return 'disconnected';
   }
 
-  async setEncoding(type: string): Promise<unknown> {
-    if (type === 'ascii') {
-      return this.ftp.ascii();
-    }
-  }
-
-  async setFiletype(filetype: string): Promise<unknown> {
-    if (filetype === 'jes' || filetype === 'seq') {
-      return this.ftp.site('FILETYPE=' + filetype);
-    }
-  }
-
   // Returns the raw LIST lines for the JES held queue.
   async pollJobs(config: FtpConfig): Promise<string[]> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('jes');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('jes');
     return this.ftp.list('');
   }
 
   // STOR a job. `contentString` is the editor contents.
   async submitJob(config: FtpConfig, contentString: string): Promise<string> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('jes');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('jes');
     await this.ftp.put(Buffer.from(contentString), '/');
     return 'submitted';
   }
 
   // Retrieve a job's spool output (RETR <jobID>.x) as a string.
   async retrieveJob(config: FtpConfig, jobID: string): Promise<string> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('jes');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('jes');
     const stream = await this.ftp.get(jobID + '.x');
     return this._streamToString(stream);
   }
 
   async deleteJob(config: FtpConfig, jobID: string): Promise<string> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('jes');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('jes');
     await this.ftp.delete(jobID);
     return 'deleted';
   }
 
   // Returns raw LIST lines for the datasets at the home qualifier.
   async listDatasets(config: FtpConfig): Promise<string[]> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('seq');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('seq');
     return this.ftp.list('');
   }
 
   // Returns raw LIST lines for the members of `dsname`.
   async listMembers(config: FtpConfig, dsname: string): Promise<string[]> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('seq');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('seq');
     try {
       await this.ftp.cwd(dsname);
       const rows = await this.ftp.list('');
@@ -158,37 +193,57 @@ class JES {
 
   // Retrieve the contents of a member as a string.
   async retrieveMember(config: FtpConfig, dsname: string, member: string): Promise<string> {
-    await this.connect(config);
-    await this.setEncoding('ascii');
-    await this.setFiletype('seq');
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('seq');
     try {
       await this.ftp.cwd('~');
       await this.ftp.cwd(dsname);
       const stream = await this.ftp.get(member);
       return await this._streamToString(stream);
     } finally {
-      try { await this.ftp.cwd('~'); } catch { /* best-effort reset */ }
+      try { await this.ftp.cwd('~'); } catch { /* best-effort */ }
     }
   }
 
-  // --- private helpers ----------------------------------------------------
+  // Atomic compound operation: list all datasets AND all their members in a
+  // single queued call.  Keeping this in one IPC round-trip prevents a
+  // concurrent pollJobStatus from slipping its FTP commands between the
+  // individual listMembers calls that the renderer used to make in a loop.
+  //
+  // Returns the raw rows so parsing (parseDatasets / parseMembers) stays in
+  // the renderer alongside the existing jesParse unit tests.
+  async listDatasetsWithMembers(config: FtpConfig): Promise<{
+    datasetRows: string[];
+    memberRowsByDs: Record<string, string[]>;
+  }> {
+    await this._ensureConnected(config);
+    await this._setEncoding('ascii');
+    await this._setFiletype('seq');
 
-  private _streamToString(stream: NodeJS.ReadableStream): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let data = '';
-      stream.on('data', (chunk: Buffer | string) => { data += chunk.toString(); });
-      stream.on('end', () => resolve(data));
-      stream.on('error', reject);
-      // CRITICAL: node-ftp hands back a PAUSED data socket. On modern Node,
-      // attaching a 'data' listener to an explicitly-paused stream does NOT
-      // auto-resume it, so without this call the stream never flows and the
-      // transfer hangs forever. This is the latent bug from issue #16.
-      stream.resume();
-    });
-  }
+    const datasetRows = await this.ftp.list('');
 
-  private _sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => setTimeout(resolve, ms));
+    // Extract the dsname from each row (10th space-separated column, matching
+    // the parseDatasets column order in jesParse.ts). Slice off the header row.
+    const dsnames = datasetRows
+      .slice(1)
+      .map(row => row.trim().split(/\s+/)[9] ?? '')
+      .filter(Boolean);
+
+    const memberRowsByDs: Record<string, string[]> = {};
+    for (const dsname of dsnames) {
+      try {
+        await this.ftp.cwd(dsname);
+        memberRowsByDs[dsname] = await this.ftp.list('');
+      } catch {
+        // Empty / unreadable PDS — treat as no members (mirrors listMembers).
+        memberRowsByDs[dsname] = [];
+      } finally {
+        try { await this.ftp.cwd('~'); } catch { /* best-effort reset */ }
+      }
+    }
+
+    return { datasetRows, memberRowsByDs };
   }
 }
 
@@ -198,6 +253,19 @@ const jes = new JES();
 // IPC handlers
 // --------------------------------------------------------------------------
 function registerIpc(): void {
+  // Serial queue — ensures only one FTP operation runs at a time.
+  // Concurrent IPC calls queue behind the current operation instead of
+  // interleaving their commands on the shared PromiseFtp connection.
+  // Each fn runs after the previous one completes (or fails — errors in one
+  // operation do not block the queue from draining).
+  let _ftpQueue: Promise<unknown> = Promise.resolve();
+  function enqueue<T>(fn: () => Promise<T>): Promise<T> {
+    // Absorb the ticket's own rejection on _ftpQueue so the chain stays live.
+    const ticket = _ftpQueue.then(fn, fn);
+    _ftpQueue = ticket.then(() => {}, () => {});
+    return ticket;
+  }
+
   // --- file dialogs + fs ---
   ipcMain.handle('file:open', async (): Promise<OpenFileResult | null> => {
     const result = await dialog.showOpenDialog(mainWindow!, {
@@ -255,25 +323,45 @@ function registerIpc(): void {
     }
   );
 
-  // --- JES / FTP ---
-  ipcMain.handle('jes:connect', (_evt: IpcMainInvokeEvent, config: FtpConfig) => jes.connect(config));
-  ipcMain.handle('jes:disconnect', () => jes.disconnect());
-  ipcMain.handle('jes:pollJobs', (_evt: IpcMainInvokeEvent, config: FtpConfig) => jes.pollJobs(config));
-  ipcMain.handle('jes:submitJob', (_evt: IpcMainInvokeEvent, config: FtpConfig, content: string) =>
-    jes.submitJob(config, content));
-  ipcMain.handle('jes:retrieveJob', (_evt: IpcMainInvokeEvent, config: FtpConfig, jobID: string) =>
-    jes.retrieveJob(config, jobID));
-  ipcMain.handle('jes:deleteJob', (_evt: IpcMainInvokeEvent, config: FtpConfig, jobID: string) =>
-    jes.deleteJob(config, jobID));
-  ipcMain.handle('jes:listDatasets', (_evt: IpcMainInvokeEvent, config: FtpConfig) =>
-    jes.listDatasets(config));
-  ipcMain.handle('jes:listMembers', (_evt: IpcMainInvokeEvent, config: FtpConfig, dsname: string) =>
-    jes.listMembers(config, dsname));
-  ipcMain.handle(
-    'jes:retrieveMember',
+  // --- JES / FTP — all wrapped through the serial queue ---
+  ipcMain.handle('jes:connect',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig) =>
+      enqueue(() => jes.connect(config)));
+
+  ipcMain.handle('jes:disconnect',
+    () => enqueue(() => jes.disconnect()));
+
+  ipcMain.handle('jes:pollJobs',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig) =>
+      enqueue(() => jes.pollJobs(config)));
+
+  ipcMain.handle('jes:submitJob',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig, content: string) =>
+      enqueue(() => jes.submitJob(config, content)));
+
+  ipcMain.handle('jes:retrieveJob',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig, jobID: string) =>
+      enqueue(() => jes.retrieveJob(config, jobID)));
+
+  ipcMain.handle('jes:deleteJob',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig, jobID: string) =>
+      enqueue(() => jes.deleteJob(config, jobID)));
+
+  ipcMain.handle('jes:listDatasets',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig) =>
+      enqueue(() => jes.listDatasets(config)));
+
+  ipcMain.handle('jes:listMembers',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig, dsname: string) =>
+      enqueue(() => jes.listMembers(config, dsname)));
+
+  ipcMain.handle('jes:retrieveMember',
     (_evt: IpcMainInvokeEvent, config: FtpConfig, dsname: string, member: string) =>
-      jes.retrieveMember(config, dsname, member)
-  );
+      enqueue(() => jes.retrieveMember(config, dsname, member)));
+
+  ipcMain.handle('jes:listDatasetsWithMembers',
+    (_evt: IpcMainInvokeEvent, config: FtpConfig) =>
+      enqueue(() => jes.listDatasetsWithMembers(config)));
 }
 
 // --------------------------------------------------------------------------

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -33,7 +33,9 @@ const api: KeypunchApi = {
     listDatasets: (config) => ipcRenderer.invoke('jes:listDatasets', config),
     listMembers: (config, dsname) => ipcRenderer.invoke('jes:listMembers', config, dsname),
     retrieveMember: (config, dsname, member) =>
-      ipcRenderer.invoke('jes:retrieveMember', config, dsname, member)
+      ipcRenderer.invoke('jes:retrieveMember', config, dsname, member),
+    listDatasetsWithMembers: (config) =>
+      ipcRenderer.invoke('jes:listDatasetsWithMembers', config)
   },
 
   // --- main -> renderer menu events ---


### PR DESCRIPTION
## Summary

- **Serial FTP queue** (`electron/main.ts`): added an `enqueue()` helper in `registerIpc()` that wraps every `jes:*` IPC handler. Only one FTP operation runs at a time; a second UI action that fires while the first is in flight queues behind it rather than interleaving `SITE FILETYPE=` and `LIST` commands on the shared `PromiseFtp` connection.
- **Atomic compound listing** (`JES.listDatasetsWithMembers`): new method that performs the complete dataset + all-member listing in one queued call. The renderer (`jesFtp.ts`) calls this single IPC method instead of the former loop (`jes:listDatasets` + N × `jes:listMembers`), which left gaps where a concurrent `pollJobStatus` could slip in and switch the connection to `FILETYPE=JES` mid-loop.
- **Internal refactor** (`JES` class): `setEncoding`, `setFiletype`, and the connect check are now private helpers (`_setEncoding`, `_setFiletype`, `_ensureConnected`). Public methods use these helpers and must not call each other (which would deadlock through the queue).
- **Type contract** updated: `listDatasetsWithMembers` added to `KeypunchJesApi` in `keypunch.d.ts` and wired into `preload.ts`.

## What was broken (issue #2)

```
getMVSJobs (pollJobStatus)   |  getDatasets (listDatasets loop)
─────────────────────────────┼────────────────────────────────
SITE FILETYPE=JES            |
                             |  SITE FILETYPE=SEQ
                             |  LIST '' → dataset rows
                             |  CWD DS1
LIST ''                      |             ← lists DS1 members, returned as jobs!
                             |  CWD ~
                             |  CWD DS2
                             |  …
```

Both the serial queue and the compound call are needed: the queue prevents individual FTP commands from interleaving; the compound call removes the IPC-level gaps between member listings.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 22/22 unit + integration tests pass (pre-existing e2e Playwright/Vitest conflict is unrelated)
- [ ] Manual smoke test against a real z/OS FTP endpoint (requires mainframe access)

🤖 Generated with [Claude Code](https://claude.com/claude-code)