### PR TITLE
fix: add FTPS opt-in and move password out of FtpConfig IPC payload (closes #12)

### DIFF
--- a/app/actions/configForm.ts
+++ b/app/actions/configForm.ts
@@ -3,6 +3,7 @@ import {
   SET_FTP_PORT,
   SET_FTP_USER_NAME,
   SET_FTP_PASSWORD,
+  SET_FTPS_ENABLED,
 } from '../constants';
 
 export const setHostName = (hostName: string) => ({
@@ -25,8 +26,14 @@ export const setFtpPassword = (ftpPassword: string) => ({
   ftpPassword,
 });
 
+export const setFtpsEnabled = (ftpsEnabled: boolean) => ({
+  type: SET_FTPS_ENABLED,
+  ftpsEnabled,
+});
+
 export type ConfigFormAction =
   | ReturnType<typeof setHostName>
   | ReturnType<typeof setFtpPort>
   | ReturnType<typeof setFtpUserName>
-  | ReturnType<typeof setFtpPassword>;
+  | ReturnType<typeof setFtpPassword>
+  | ReturnType<typeof setFtpsEnabled>;

--- a/app/components/ConfigForm.tsx
+++ b/app/components/ConfigForm.tsx
@@ -1,5 +1,6 @@
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
-import { setHostName, setFtpPort, setFtpUserName, setFtpPassword } from '../actions/configForm';
+import { setHostName, setFtpPort, setFtpUserName, setFtpPassword, setFtpsEnabled } from '../actions/configForm';
 import { setThemeDark, setThemeLight } from '../actions/uiStyle';
 import type { RootState } from '../reducers';
 import type { AppDispatch } from '../store/configureStore';
@@ -10,6 +11,7 @@ function mapStateToProps(state: RootState) {
     ftpPort:     state.config.ftpPort,
     ftpUserName: state.config.ftpUserName,
     ftpPassword: state.config.ftpPassword,
+    ftpsEnabled: state.config.ftpsEnabled,
     theme:       state.uiStyle.theme,
     color:       state.uiStyle.color,
   };
@@ -17,12 +19,13 @@ function mapStateToProps(state: RootState) {
 
 function mapDispatchToProps(dispatch: AppDispatch) {
   return {
-    setHostName:    (hostName: string)    => dispatch(setHostName(hostName)),
-    setFtpPort:     (ftpPort: string)     => dispatch(setFtpPort(ftpPort)),
-    setFtpUserName: (ftpUserName: string) => dispatch(setFtpUserName(ftpUserName)),
-    setFtpPassword: (ftpPassword: string) => dispatch(setFtpPassword(ftpPassword)),
-    setThemeDark:   ()                    => dispatch(setThemeDark()),
-    setThemeLight:  ()                    => dispatch(setThemeLight()),
+    setHostName:    (hostName: string)       => dispatch(setHostName(hostName)),
+    setFtpPort:     (ftpPort: string)        => dispatch(setFtpPort(ftpPort)),
+    setFtpUserName: (ftpUserName: string)    => dispatch(setFtpUserName(ftpUserName)),
+    setFtpPassword: (ftpPassword: string)    => dispatch(setFtpPassword(ftpPassword)),
+    setFtpsEnabled: (ftpsEnabled: boolean)   => dispatch(setFtpsEnabled(ftpsEnabled)),
+    setThemeDark:   ()                       => dispatch(setThemeDark()),
+    setThemeLight:  ()                       => dispatch(setThemeLight()),
   };
 }
 
@@ -33,6 +36,13 @@ function ConfigForm(props: Props) {
   const inputStyle = props.theme === 'dark'
     ? { background: 'black', color: 'white' }
     : { background: 'white', color: 'black' };
+
+  // Keep main-process credential store in sync whenever the username or
+  // password changes (including on initial mount so the first FTP call
+  // succeeds even if the user never changes the fields after app start).
+  useEffect(() => {
+    window.keypunch.jes.setCredentials(props.ftpUserName, props.ftpPassword);
+  }, [props.ftpUserName, props.ftpPassword]);
 
   return (
     <div className="config-form">
@@ -68,6 +78,20 @@ function ConfigForm(props: Props) {
         value={props.ftpPassword}
         onChange={(evt) => props.setFtpPassword(evt.target.value)}
       />
+      <label className="config-label" style={{ color: labelColor }}>Use FTPS (TLS)</label>
+      <label className="config-radio" style={{ color: labelColor }}>
+        <input
+          type="checkbox"
+          checked={props.ftpsEnabled}
+          onChange={(evt) => props.setFtpsEnabled(evt.target.checked)}
+        />
+        {' '}Encrypt connection with AUTH TLS
+        {props.ftpsEnabled && (
+          <span style={{ marginLeft: '6px', fontSize: '0.85em', opacity: 0.7 }}>
+            (requires TLS-enabled z/OS FTP server)
+          </span>
+        )}
+      </label>
       <label className="config-label" style={{ color: labelColor }}>Theme</label>
       <div className="config-radios">
         <label className="config-radio" style={{ color: labelColor }}>

--- a/app/constants.ts
+++ b/app/constants.ts
@@ -3,10 +3,11 @@ export const SET_EDITOR_PATH     = 'SET_EDITOR_PATH'     as const;
 
 export const SET_EXPLORER_CONTENT = 'SET_EXPLORER_CONTENT' as const;
 
-export const SET_HOST_NAME     = 'SET_HOST_NAME'     as const;
-export const SET_FTP_PORT      = 'SET_FTP_PORT'      as const;
-export const SET_FTP_USER_NAME = 'SET_FTP_USER_NAME' as const;
-export const SET_FTP_PASSWORD  = 'SET_FTP_PASSWORD'  as const;
+export const SET_HOST_NAME      = 'SET_HOST_NAME'      as const;
+export const SET_FTP_PORT       = 'SET_FTP_PORT'       as const;
+export const SET_FTP_USER_NAME  = 'SET_FTP_USER_NAME'  as const;
+export const SET_FTP_PASSWORD   = 'SET_FTP_PASSWORD'   as const;
+export const SET_FTPS_ENABLED   = 'SET_FTPS_ENABLED'   as const;
 
 export const SET_THEME_DARK = 'SET_THEME_DARK' as const;
 export const SET_THEME_LIGHT = 'SET_THEME_LIGHT' as const;

--- a/app/keypunch.d.ts
+++ b/app/keypunch.d.ts
@@ -7,13 +7,19 @@
 // are type-checked against a single source of truth.
 
 // The FTP/JES connection config. Pulled out of redux in the renderer
-// (app/utils/jesFtp.js getConfig) and consumed by main's JES methods. Ports
+// (app/utils/jesFtp.ts getConfig) and consumed by main's JES methods. Ports
 // come from a text input, hence string.
+//
+// NOTE: ftpPassword is intentionally absent. Credentials are sent to main
+// exactly once via jes:setCredentials whenever they change, and main stores
+// them internally. This avoids re-transmitting the password on every IPC
+// call (pollJobs, listDatasetsWithMembers, etc.).
 export interface FtpConfig {
   hostName: string;
   ftpPort: string;
   ftpUserName: string;
-  ftpPassword: string;
+  /** When true the FTP control connection is upgraded to TLS (AUTH TLS / explicit FTPS). */
+  ftpsEnabled: boolean;
 }
 
 // Options for the generic yes/no confirm dialog.
@@ -45,6 +51,12 @@ export type MenuChannel =
 // All calls are serialized through a single queue in main so FTP commands
 // from concurrent renderer actions never interleave on the shared connection.
 export interface KeypunchJesApi {
+  /**
+   * Send credentials to the main process for storage.  Must be called (and
+   * awaited) before any FTP operation.  The password is NOT included in
+   * FtpConfig so it is not re-transmitted on every IPC call.
+   */
+  setCredentials(username: string, password: string): Promise<void>;
   connect(config: FtpConfig): Promise<string>;
   disconnect(): Promise<string>;
   pollJobs(config: FtpConfig): Promise<string[]>;

--- a/app/reducers/config.ts
+++ b/app/reducers/config.ts
@@ -3,6 +3,7 @@ import {
   SET_FTP_PORT,
   SET_FTP_USER_NAME,
   SET_FTP_PASSWORD,
+  SET_FTPS_ENABLED,
 } from '../constants';
 import type { ConfigFormAction } from '../actions/configForm';
 
@@ -10,7 +11,13 @@ export interface ConfigState {
   hostName: string;
   ftpPort: string;
   ftpUserName: string;
+  /** Held in Redux for the controlled password input only.
+   *  NOT included in FtpConfig IPC payloads — the actual credential used
+   *  for FTP connections is stored in the main process via jes:setCredentials.
+   */
   ftpPassword: string;
+  /** When true, the FTP connection uses explicit FTPS (AUTH TLS). */
+  ftpsEnabled: boolean;
 }
 
 const initialConfigState: ConfigState = {
@@ -18,6 +25,7 @@ const initialConfigState: ConfigState = {
   ftpPort: '21',
   ftpUserName: '',
   ftpPassword: '',
+  ftpsEnabled: false,
 };
 
 export default function config(
@@ -38,6 +46,9 @@ export default function config(
       break;
     case SET_FTP_PASSWORD:
       newState.ftpPassword = action.ftpPassword;
+      break;
+    case SET_FTPS_ENABLED:
+      newState.ftpsEnabled = action.ftpsEnabled;
       break;
     default:
       return state;

--- a/app/utils/jesFtp.ts
+++ b/app/utils/jesFtp.ts
@@ -30,14 +30,16 @@ import { refreshDatasets } from '../actions/datasets';
 import { parseJobs, parseDatasets, parseMembers } from './jesParse';
 import type { FtpConfig } from '../keypunch';
 
-// Pull the FTP config out of Redux. This is exactly the shape main expects.
+// Pull the FTP config out of Redux. Password is intentionally excluded —
+// it is stored in the main process via jes:setCredentials and must not be
+// re-transmitted on every IPC call.
 function getConfig(): FtpConfig {
   const { config } = store.getState();
   return {
-    hostName: config.hostName,
-    ftpPort: config.ftpPort,
+    hostName:    config.hostName,
+    ftpPort:     config.ftpPort,
     ftpUserName: config.ftpUserName,
-    ftpPassword: config.ftpPassword,
+    ftpsEnabled: config.ftpsEnabled,
   };
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -46,6 +46,11 @@ let mainWindow: BrowserWindow | null = null;
 // --------------------------------------------------------------------------
 class JES {
   private ftp: PromiseFtp;
+  // Credentials are stored here after the renderer calls jes:setCredentials.
+  // They are intentionally NOT carried in FtpConfig (the per-call IPC payload)
+  // so the password is not re-transmitted on every pollJobs / listDatasets call.
+  private _username = '';
+  private _password = '';
 
   constructor() {
     this.ftp = new PromiseFtp();
@@ -58,10 +63,14 @@ class JES {
   private async _ensureConnected(config: FtpConfig): Promise<void> {
     if (this.ftp.getConnectionStatus() === 'connected') return;
     await this.ftp.connect({
-      host: config.hostName,
-      port: config.ftpPort,
-      user: config.ftpUserName,
-      password: config.ftpPassword
+      host:     config.hostName,
+      port:     config.ftpPort,
+      user:     this._username,
+      password: this._password,
+      // `true` → explicit FTPS (AUTH TLS): the control connection is
+      // established in plaintext and then upgraded with AUTH TLS.
+      // `false` → plain FTP (default; required for z/OS servers without TLS).
+      secure: config.ftpsEnabled ? true : false,
     });
   }
 
@@ -98,6 +107,13 @@ class JES {
   // Called through the serial queue in registerIpc(); never call these
   // from within another public method (use the private helpers instead).
   // -----------------------------------------------------------------------
+
+  // Store credentials. Called by the renderer whenever the username or
+  // password field changes; must be called before the first FTP operation.
+  setCredentials(username: string, password: string): void {
+    this._username = username;
+    this._password = password;
+  }
 
   async connect(config: FtpConfig): Promise<string> {
     await this._ensureConnected(config);
@@ -324,6 +340,14 @@ function registerIpc(): void {
   );
 
   // --- JES / FTP — all wrapped through the serial queue ---
+
+  // setCredentials is synchronous on the main side and does not touch the FTP
+  // connection, so it runs outside the queue.  This also avoids a deadlock if
+  // the renderer calls setCredentials while another operation is queued.
+  ipcMain.handle('jes:setCredentials',
+    (_evt: IpcMainInvokeEvent, username: string, password: string) =>
+      jes.setCredentials(username, password));
+
   ipcMain.handle('jes:connect',
     (_evt: IpcMainInvokeEvent, config: FtpConfig) =>
       enqueue(() => jes.connect(config)));

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -24,6 +24,8 @@ const api: KeypunchApi = {
   // --- JES / FTP (all I/O runs in main; raw results come back to be parsed
   //     by the renderer's jesParse.ts) ---
   jes: {
+    setCredentials: (username, password) =>
+      ipcRenderer.invoke('jes:setCredentials', username, password),
     connect: (config) => ipcRenderer.invoke('jes:connect', config),
     disconnect: () => ipcRenderer.invoke('jes:disconnect'),
     pollJobs: (config) => ipcRenderer.invoke('jes:pollJobs', config),

--- a/electron/promise-ftp.d.ts
+++ b/electron/promise-ftp.d.ts
@@ -13,6 +13,10 @@ declare module 'promise-ftp' {
     port?: number | string;
     user?: string;
     password?: string;
+    /** `true` → explicit FTPS (AUTH TLS); `'implicit'` → implicit FTPS (port 990).
+     *  Passed through to the underlying @icetee/ftp client. */
+    secure?: boolean | 'implicit';
+    secureOptions?: object;
   }
 
   class PromiseFtp {


### PR DESCRIPTION
## Summary

Addresses both concerns from issue #12:

### FTPS (AUTH TLS) opt-in
- New `ftpsEnabled` boolean in `ConfigState` / `FtpConfig` / Redux (default `false` = plain FTP, unchanged behaviour)
- "Use FTPS (TLS)" checkbox added to `ConfigForm`; shows a note that it requires a TLS-capable z/OS FTP server — opt-in rather than forced, so plain-FTP-only mainframes still work
- `JES._ensureConnected` now passes `secure: config.ftpsEnabled` to `promise-ftp` / `@icetee/ftp`, which already implements AUTH TLS (explicit FTPS) — just needed to be plumbed through
- `secure` and `secureOptions` added to the ambient `promise-ftp.d.ts` declaration

### Password out of the per-call FtpConfig IPC payload
- `FtpConfig` loses `ftpPassword` — previously the password was re-transmitted on every `pollJobs`, `listDatasets`, `submitJob`, etc. IPC call even after the connection was already established
- New `JES.setCredentials(username, password)` stores them in main-process memory; `_ensureConnected` reads from there
- New `jes:setCredentials` IPC handler — registered **outside** the FTP serial queue since it's synchronous and does not touch the socket (no deadlock risk)
- `ConfigForm` gains a `useEffect([ftpUserName, ftpPassword])` that calls `window.keypunch.jes.setCredentials` on mount **and** on every field change, keeping main's store in sync
- `ftpPassword` remains in Redux for the controlled password input — it is not persisted to disk and never was; the improvement is that it is no longer re-sent over IPC on every FTP operation

## What was NOT changed
- Password is still held in Redux state for the controlled input (removing it would require refactoring to uncontrolled/local component state with no meaningful security gain for a local Electron app)
- No OS keychain integration (mentioned in the issue as future hardening; requires platform-specific APIs)
- Implicit FTPS (port 990) is not exposed in the UI — the `secure` type allows `'implicit'` but the toggle only enables `true` (AUTH TLS); implicit FTPS is uncommon on z/OS

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 22/22 unit + integration tests pass
- [ ] Manual: config form shows FTPS checkbox; toggling it does not break plain-FTP path
- [ ] Manual: with a TLS-capable z/OS FTP server, enabling FTPS produces an encrypted connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)