### PR TITLE
feat: packaging CI + fix electron-builder icon config (closes #30)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,104 @@
+name: Package
+
+# Build branded installers on every version tag or on demand.
+# Each platform job runs on its native runner so electron-builder can
+# produce native artifacts (NSIS, DMG, AppImage/deb).
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  package:
+    name: Package (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            script: package-linux
+          - os: windows-latest
+            script: package-win
+          - os: macos-latest
+            script: package-mac
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Build and package
+        run: npm run ${{ matrix.script }}
+
+      - name: List release artifacts
+        shell: bash
+        run: ls -lh release/
+
+      # ── Linux smoke-launch ────────────────────────────────────────────────
+      - name: Install AppImage runtime dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y xvfb libgtk-3-0 libnss3 libasound2t64 libfuse2
+
+      - name: Smoke-launch AppImage
+        if: runner.os == 'Linux'
+        run: |
+          APPIMAGE=$(ls release/*.AppImage | head -1)
+          echo "Launching: $APPIMAGE"
+          chmod +x "$APPIMAGE"
+          # Run under xvfb; timeout after 10 s. Exit 124 = timeout = app stayed alive = pass.
+          xvfb-run -a timeout 10 "$APPIMAGE" --no-sandbox
+          CODE=$?
+          [ $CODE -eq 0 ] || [ $CODE -eq 124 ] || (echo "AppImage crashed with exit $CODE" && exit 1)
+
+      # ── macOS smoke-launch ────────────────────────────────────────────────
+      - name: Smoke-launch DMG
+        if: runner.os == 'macOS'
+        run: |
+          DMG=$(ls release/*.dmg | head -1)
+          echo "Attaching: $DMG"
+          hdiutil attach "$DMG" -nobrowse -quiet
+          # Verify the branded app bundle and executable exist inside the DMG.
+          APP=$(find /Volumes -maxdepth 2 -name "Keypunch.app" 2>/dev/null | head -1)
+          echo "App bundle: $APP"
+          test -n "$APP" || (echo "Keypunch.app not found in DMG" && exit 1)
+          test -f "$APP/Contents/MacOS/Keypunch" || (echo "Keypunch binary missing" && exit 1)
+          # Launch briefly; timeout exit 124 = app ran without immediate crash.
+          timeout 10 "$APP/Contents/MacOS/Keypunch" --no-sandbox || [ $? -eq 124 ]
+          hdiutil detach "$(dirname "$APP")" -quiet || true
+
+      # ── Windows smoke-launch ──────────────────────────────────────────────
+      - name: Smoke-launch NSIS installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $exe = Get-ChildItem release -Filter "*.exe" | Select-Object -First 1
+          if (-not $exe) { throw "No installer found in release/" }
+          Write-Host "Installer: $($exe.FullName)  ($([Math]::Round($exe.Length/1MB,1)) MB)"
+          # Validate PE MZ header.
+          $bytes = [IO.File]::ReadAllBytes($exe.FullName)
+          if ($bytes[0] -ne 77 -or $bytes[1] -ne 90) { throw "Not a valid PE executable" }
+          Write-Host "PE header OK"
+
+      # ── Upload artifacts ──────────────────────────────────────────────────
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: keypunch-${{ runner.os }}
+          path: |
+            release/*.exe
+            release/*.dmg
+            release/*.AppImage
+            release/*.deb
+          if-no-files-found: error

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "package": "electron-vite build && electron-builder --publish never",
+    "package-mac": "electron-vite build && electron-builder --mac",
     "package-win": "electron-vite build && electron-builder --win --x64",
     "package-linux": "electron-vite build && electron-builder --linux",
     "package-all": "electron-vite build && electron-builder -mwl"
@@ -39,19 +40,24 @@
         }
       ]
     },
+    "directories": {
+      "buildResources": "resources",
+      "output": "release"
+    },
+    "mac": {
+      "icon": "resources/icons/1024x1024.png"
+    },
     "win": {
+      "icon": "resources/icon.ico",
       "target": "nsis"
     },
     "linux": {
+      "icon": "resources/icons",
       "target": [
         "deb",
         "AppImage"
       ]
     }
-  },
-  "directories": {
-    "buildResources": "resources",
-    "output": "release"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

- **Bug fix**: `directories` was at the top-level of `package.json` instead of nested inside `build`, so electron-builder ignored it entirely — icons in `resources/` were never picked up and output went to `dist/` instead of `release/`.
- **Icon wiring**: Added explicit `icon` paths for all three platforms (`resources/icons/1024x1024.png` for macOS, `resources/icon.ico` for Windows, `resources/icons/` for Linux). On macOS electron-builder auto-converts the 1024×1024 PNG to `.icns`, so no binary asset needs to be committed.
- **New CI workflow** (`.github/workflows/package.yml`): triggers on `v*` tags and `workflow_dispatch`; runs three parallel jobs on native runners (ubuntu/windows/macos), each running the appropriate `package-*` script, then performing a platform-specific smoke test:
  - **Linux**: launches the AppImage under `xvfb-run` with a 10 s timeout (exit 124 = app stayed alive = pass)
  - **macOS**: mounts the DMG, verifies `Keypunch.app/Contents/MacOS/Keypunch` exists, brief launch with timeout
  - **Windows**: verifies the NSIS installer has a valid PE MZ header
  - All artifacts are uploaded for download from the Actions run.
- **`package-mac` script** added for CI symmetry with `package-win` / `package-linux`.

## Test plan

- [ ] Push a `v0.1.0` tag (or trigger `workflow_dispatch`) and confirm all three matrix jobs complete green
- [ ] Download each artifact and verify branding: app name "Keypunch", icon shows the punch-card logo, `appId` is `com.bushidocodes.keypunch`
- [ ] Confirm `release/` is the output directory (not `dist/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)