### PR TITLE
Fix REFRESH_JOBS to replace instead of merge

### DIFF
--- a/app/reducers/jobs.ts
+++ b/app/reducers/jobs.ts
@@ -15,10 +15,18 @@ export default function jobs(
 ): JobsState {
   switch (action.type) {
     case REFRESH_JOBS: {
-      // Replace the jobs state with the incoming snapshot. Using merge kept
-      // stale keys for jobs that were deleted on the server; a direct replace
-      // ensures the UI reflects the real queue state.
-      return { ...(action.jobsState as JobMap) } as JobsState;
+      // Replace the jobs state with the incoming snapshot so stale jobs
+      // (deleted on the server) are removed, while preserving any downloaded
+      // results for jobs that are still present in the queue.
+      const incoming = action.jobsState as JobMap;
+      const next: JobsState = {};
+      for (const [id, job] of Object.entries(incoming)) {
+        const existingResults = state[id]?.results;
+        next[id] = existingResults !== undefined
+          ? { ...(job as Job), results: existingResults }
+          : { ...(job as Job) };
+      }
+      return next;
     }
     case LOAD_JOB_RESULTS: {
       const updated = { ...state };

--- a/app/reducers/jobs.ts
+++ b/app/reducers/jobs.ts
@@ -1,4 +1,3 @@
-import merge from 'lodash/merge';
 import { REFRESH_JOBS, LOAD_JOB_RESULTS } from '../constants';
 import type { Job, JobMap } from '../utils/jesParse';
 import type { JobsAction } from '../actions/jobs';
@@ -16,10 +15,10 @@ export default function jobs(
 ): JobsState {
   switch (action.type) {
     case REFRESH_JOBS: {
-      // Merge incoming jobs into existing state so previously-downloaded results
-      // are preserved. The original code mutated in place; _.merge does the same
-      // but without the side-effect on the original state object.
-      return merge({} as JobsState, state, action.jobsState as JobMap);
+      // Replace the jobs state with the incoming snapshot. Using merge kept
+      // stale keys for jobs that were deleted on the server; a direct replace
+      // ensures the UI reflects the real queue state.
+      return { ...(action.jobsState as JobMap) } as JobsState;
     }
     case LOAD_JOB_RESULTS: {
       const updated = { ...state };

--- a/harness/unit/jobsReducer.test.js
+++ b/harness/unit/jobsReducer.test.js
@@ -48,6 +48,15 @@ describe('jobs reducer', () => {
     expect(Object.keys(state)).toHaveLength(2);
   });
 
+  it('removes jobs that are absent from the new snapshot (replace semantics)', () => {
+    // First poll: both jobs arrive.
+    let state = reducer(undefined, refreshJobs({ [JOB_A.jobID]: JOB_A, [JOB_B.jobID]: JOB_B }));
+    // Second poll: only JOB_B is returned (JOB_A finished/purged on the server).
+    state = reducer(state, refreshJobs({ [JOB_B.jobID]: JOB_B }));
+    expect(state[JOB_A.jobID]).toBeUndefined();
+    expect(state[JOB_B.jobID]).toBeDefined();
+  });
+
   it('attaches results to a specific job on LOAD_JOB_RESULTS', () => {
     let state = reducer(undefined, refreshJobs({ [JOB_A.jobID]: JOB_A }));
     state = reducer(state, loadJobResults('JOB00001', 'spool output here'));


### PR DESCRIPTION
## Summary
Replace the lodash `merge` in the jobs reducer with a direct state replacement. The merge approach left stale keys in the Redux store for jobs that were deleted on the mainframe server, causing deleted jobs to persist in the UI indefinitely.

Closes #56