### PR TITLE
Guard TEST button behind NODE_ENV development check

### DIFF
--- a/app/components/StatusBar.tsx
+++ b/app/components/StatusBar.tsx
@@ -49,9 +49,11 @@ type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchT
 function StatusBar(props: Props) {
   return (
     <div className="status-bar">
-      <button className="btn-test" onClick={props.testIndicators}>
-        TEST
-      </button>
+      {process.env.NODE_ENV === 'development' && (
+        <button className="btn-test" onClick={props.testIndicators}>
+          TEST
+        </button>
+      )}
 
       {!props.isConnected ? (
         <button className="btn-connect" onClick={props.jesConnect}>

--- a/harness/component/App.test.jsx
+++ b/harness/component/App.test.jsx
@@ -101,9 +101,18 @@ describe('App', () => {
   });
 
   describe('status bar', () => {
-    it('renders the StatusBar (TEST button visible)', () => {
+    it('renders the StatusBar with TEST button visible in development', () => {
+      vi.stubEnv('NODE_ENV', 'development');
       renderApp();
       expect(screen.getByRole('button', { name: 'TEST' })).toBeInTheDocument();
+      vi.unstubAllEnvs();
+    });
+
+    it('renders the StatusBar without TEST button in production', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      renderApp();
+      expect(screen.queryByRole('button', { name: 'TEST' })).not.toBeInTheDocument();
+      vi.unstubAllEnvs();
     });
   });
 });

--- a/harness/component/StatusBar.test.jsx
+++ b/harness/component/StatusBar.test.jsx
@@ -106,7 +106,11 @@ describe('StatusBar', () => {
   });
 
   describe('TEST button', () => {
-    it('renders the TEST button', () => {
+    // The TEST button is only rendered in development builds.
+    beforeEach(() => { vi.stubEnv('NODE_ENV', 'development'); });
+    afterEach(() => { vi.unstubAllEnvs(); });
+
+    it('renders the TEST button in development mode', () => {
       renderStatusBar();
       expect(screen.getByRole('button', { name: 'TEST' })).toBeInTheDocument();
     });
@@ -116,6 +120,12 @@ describe('StatusBar', () => {
       renderStatusBar();
       fireEvent.click(screen.getByRole('button', { name: 'TEST' }));
       expect(testIndicators).toHaveBeenCalledOnce();
+    });
+
+    it('does not render the TEST button in production mode', () => {
+      vi.stubEnv('NODE_ENV', 'production');
+      renderStatusBar();
+      expect(screen.queryByRole('button', { name: 'TEST' })).not.toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
Wrap the TEST button in StatusBar inside a `process.env.NODE_ENV === 'development'` check so it is only rendered in dev builds and does not appear in production/packaged releases.

Closes #58