### PR TITLE
feat: TEST button performs real connectivity check

### DIFF
--- a/app/components/StatusBar.tsx
+++ b/app/components/StatusBar.tsx
@@ -1,7 +1,7 @@
 import { connect } from 'react-redux';
 import Indicator from './Indicator';
 import { store } from '../index';
-import { testIndicators } from '../utils/nativeDialogs';
+import { testConnectivity } from '../utils/nativeDialogs';
 import jes from '../utils/jesFtp';
 import type { RootState } from '../reducers';
 
@@ -22,9 +22,9 @@ function mapStateToProps(state: RootState) {
 
 function mapDispatchToProps() {
   return {
-    testIndicators: (evt: React.MouseEvent) => {
+    testConnectivity: (evt: React.MouseEvent) => {
       evt.preventDefault();
-      testIndicators();
+      testConnectivity();
     },
     jesConnect: (evt: React.MouseEvent) => {
       evt.preventDefault();
@@ -49,7 +49,7 @@ type Props = ReturnType<typeof mapStateToProps> & ReturnType<typeof mapDispatchT
 function StatusBar(props: Props) {
   return (
     <div className="status-bar">
-      <button className="btn-test" onClick={props.testIndicators}>
+      <button className="btn-test" onClick={props.testConnectivity}>
         TEST
       </button>
 

--- a/app/utils/nativeDialogs.ts
+++ b/app/utils/nativeDialogs.ts
@@ -3,17 +3,8 @@
 // this module just calls those and dispatches the results into redux.
 
 import { setEditorContent, setEditorPath } from '../actions/editor';
-import {
-  setIsConnected,
-  setIsConnecting,
-  setIsSubmitted,
-  setIsSubmitting,
-  setIsRetrieved,
-  setIsRetrieving,
-  setIsDisconnected,
-  setIsDisconnecting,
-} from '../actions/results';
 import { store } from '../index';
+import jes from './jesFtp';
 
 export async function openFilePicker(): Promise<void> {
   const result = await window.keypunch.openFile();
@@ -37,26 +28,9 @@ export async function saveFile(overwrite = false): Promise<void> {
   }
 }
 
-export function testIndicators(): void {
-  const tests = [
-    () => setIsConnecting(true),
-    () => setIsConnecting(false),
-    () => setIsSubmitting(true),
-    () => setIsSubmitting(false),
-    () => setIsRetrieving(true),
-    () => setIsRetrieving(false),
-    () => setIsDisconnecting(true),
-    () => setIsDisconnecting(false),
-    () => setIsConnected(true),
-    () => setIsSubmitted(true),
-    () => setIsRetrieved(true),
-    () => setIsDisconnected(true),
-    () => setIsConnected(false),
-    () => setIsSubmitted(false),
-    () => setIsRetrieved(false),
-    () => setIsDisconnected(false),
-  ];
-  tests.forEach((test, index) => {
-    window.setTimeout(() => { store.dispatch(test()); }, 2000 * index);
-  });
+export async function testConnectivity(): Promise<void> {
+  await jes.connect();
+  if (!store.getState().results.isConnected) return;
+  await new Promise<void>(r => window.setTimeout(r, 1500));
+  await jes.disconnect();
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -121,27 +121,14 @@ class JES {
   }
 
   async disconnect(): Promise<string> {
-    let status = this.ftp.getConnectionStatus();
+    const status = this.ftp.getConnectionStatus();
     if (status === 'not yet connected' || status === 'disconnected') {
       return 'disconnected';
     }
-    try {
-      await this.ftp.end();
-    } catch {
-      // fall through to a forced destroy below
-    }
-    status = this.ftp.getConnectionStatus();
-    let numTries = 10;
-    while (status === 'disconnecting' && numTries > 0) {
-      await this._sleep(2000);
-      status = this.ftp.getConnectionStatus();
-      numTries--;
-    }
-    if (status === 'disconnecting' || status === 'connected') {
-      try { this.ftp.destroy(); } catch { /* already gone */ }
-    }
-    // promise-ftp cannot be reused after end()/destroy(); make a fresh client
-    // so a later connect() works.
+    // ftp.end() waits for socket 'close' which can stall in Electron's event
+    // loop. Destroy tears down the socket synchronously; promise-ftp cannot be
+    // reused after destroy(), so we always recreate.
+    try { this.ftp.destroy(); } catch { /* already gone */ }
     this.ftp = new PromiseFtp();
     return 'disconnected';
   }

--- a/harness/component/App.test.jsx
+++ b/harness/component/App.test.jsx
@@ -45,10 +45,10 @@ vi.mock('../../app/utils/jesFtp', () => ({
 }));
 
 vi.mock('../../app/utils/nativeDialogs', () => ({
-  testIndicators: vi.fn(),
-  openFilePicker: vi.fn(),
-  newFile:        vi.fn(),
-  saveFile:       vi.fn(),
+  testConnectivity: vi.fn(),
+  openFilePicker:   vi.fn(),
+  newFile:          vi.fn(),
+  saveFile:         vi.fn(),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/harness/component/StatusBar.test.jsx
+++ b/harness/component/StatusBar.test.jsx
@@ -46,10 +46,10 @@ vi.mock('../../app/utils/jesFtp', () => ({
 // Stub nativeDialogs so the TEST button doesn't fire a cascade of setTimeout
 // dispatches that would bleed into subsequent tests.
 vi.mock('../../app/utils/nativeDialogs', () => ({
-  testIndicators: vi.fn(),
-  openFilePicker: vi.fn(),
-  newFile:        vi.fn(),
-  saveFile:       vi.fn(),
+  testConnectivity: vi.fn(),
+  openFilePicker:   vi.fn(),
+  newFile:          vi.fn(),
+  saveFile:         vi.fn(),
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -111,11 +111,11 @@ describe('StatusBar', () => {
       expect(screen.getByRole('button', { name: 'TEST' })).toBeInTheDocument();
     });
 
-    it('calls testIndicators when the TEST button is clicked', async () => {
-      const { testIndicators } = await import('../../app/utils/nativeDialogs');
+    it('calls testConnectivity when the TEST button is clicked', async () => {
+      const { testConnectivity } = await import('../../app/utils/nativeDialogs');
       renderStatusBar();
       fireEvent.click(screen.getByRole('button', { name: 'TEST' }));
-      expect(testIndicators).toHaveBeenCalledOnce();
+      expect(testConnectivity).toHaveBeenCalledOnce();
     });
   });
 


### PR DESCRIPTION
## Summary

- Replaces the TEST button's 32-second indicator light animation with a real connectivity probe: `jes.connect()` → 1.5 s hold (CONN lamp lights solid) → `jes.disconnect()`
- On success: CONN lamp cycles on then off, confirming TCP+FTP reachability without submitting any JCL or JES commands
- On failure: error banner appears with the connection error (ECONNREFUSED, auth failure, etc.) and all lamps stay dark
- Removes the now-unused action-creator imports (`setIsConnected`, `setIsConnecting`, etc.) from `nativeDialogs.ts`

Also fixes a latent `disconnect()` bug in the Electron main process: `ftp.end()` waited for a TCP socket `'close'` event that stalled for 8+ seconds under Electron's event loop (the same call resolves in ~2ms in plain Node). Replaced with `ftp.destroy()` + `new PromiseFtp()`, which tears down synchronously. This affected the INTERRUPT button too, not just TEST.

Supersedes #61 (which guarded TEST behind `NODE_ENV=development` as a stopgap).

## Test plan

- [x] `npm test` — 110/110 pass
- [x] `npm run typecheck` — clean
- [x] Manual Playwright CDP verification against mock JES server:
  - Good port → CONN lamp lights at ~130ms, clears at ~1550ms, button returns to CONNECT
  - Bad port → error banner appears, all lamps stay dark
  - Rapid double-click → both sequences drain cleanly, no phantom state

🤖 Generated with [Claude Code](https://claude.com/claude-code)