### PR TITLE
chore: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,8 @@ jobs:
     name: Lint (ESLint)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -34,8 +34,8 @@ jobs:
     name: Typecheck (tsc)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -52,8 +52,8 @@ jobs:
       run:
         working-directory: harness
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -73,8 +73,8 @@ jobs:
     name: Build (electron-vite)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -90,8 +90,8 @@ jobs:
     name: E2E (Playwright _electron + xvfb)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -27,9 +27,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: npm
@@ -93,7 +93,7 @@ jobs:
 
       # ── Upload artifacts ──────────────────────────────────────────────────
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: keypunch-${{ runner.os }}
           path: |


### PR DESCRIPTION
## Summary
Bumps all GitHub Actions workflow steps to their current latest major versions.
Each target version was verified against the action repo releases page.

## Changes
- `actions/checkout` @v4 -> @v6 (ci.yml, package.yml)
- `actions/setup-node` @v4 -> @v6 (ci.yml, package.yml)
- `actions/upload-artifact` @v4 -> @v7 (package.yml)

## Verified latest versions
| Action | Latest |
|--------|--------|
| actions/checkout | v6.0.3 |
| actions/setup-node | v6.4.0 |
| actions/setup-java | v5.2.0 |
| actions/setup-python | v6.2.0 |
| actions/cache | v5.0.5 |
| actions/upload-artifact | v7.0.1 |
| actions/deploy-pages | v5.0.0 |
| actions/upload-pages-artifact | v5.0.0 |
| actions/configure-pages | v6.0.0 |
| pnpm/action-setup | v6.0.8 |
| gradle/actions/setup-gradle | v6.1.1 |
| alire-project/setup-alire | v6.0.0 |

## Merge criteria
Safe to merge if CI passes.
