### PR TITLE
feat: migrate package to ESM ("type": "module")

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: '1'
       - run: npm run build
       - name: Verify build artifacts
-        run: test -f out/main/main.js && test -f out/preload/preload.js && test -f out/renderer/index.html
+        run: test -f out/main/main.cjs && test -f out/preload/preload.cjs && test -f out/renderer/index.html
 
   e2e:
     name: E2E (Playwright _electron + xvfb)

--- a/app/components/Editor.tsx
+++ b/app/components/Editor.tsx
@@ -1,4 +1,4 @@
-import AceEditor from 'react-ace';
+import AceEditor from '../utils/react-ace';
 import 'ace-builds/src-noconflict/mode-cobol';
 import 'ace-builds/src-noconflict/theme-github';
 import 'ace-builds/src-noconflict/theme-twilight';

--- a/app/components/Explorer.tsx
+++ b/app/components/Explorer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import AceEditor from 'react-ace';
+import AceEditor from '../utils/react-ace';
 import 'ace-builds/src-noconflict/mode-cobol';
 import 'ace-builds/src-noconflict/theme-github';
 import 'ace-builds/src-noconflict/theme-twilight';

--- a/app/components/Results.tsx
+++ b/app/components/Results.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import AceEditor from 'react-ace';
+import AceEditor from '../utils/react-ace';
 import 'ace-builds/src-noconflict/mode-cobol';
 import 'ace-builds/src-noconflict/theme-github';
 import 'ace-builds/src-noconflict/theme-twilight';

--- a/app/utils/react-ace.ts
+++ b/app/utils/react-ace.ts
@@ -1,0 +1,14 @@
+// With "type": "module" in package.json, rollup uses isNodeMode=1 for __toESM(),
+// which ignores __esModule: true on CJS packages. For react-ace (which uses
+// exports.__esModule = true; exports.default = AceEditor), this causes the default
+// import to resolve to the whole module.exports object instead of the component.
+// Detect and unwrap explicitly.
+import _AceEditor from 'react-ace';
+
+type AceModule = { __esModule: true; default: typeof _AceEditor };
+const mod: unknown = _AceEditor;
+const isWrapped = (m: unknown): m is AceModule =>
+  typeof m === 'object' && m !== null && '__esModule' in m;
+
+const AceEditor: typeof _AceEditor = isWrapped(mod) ? mod.default : (mod as typeof _AceEditor);
+export default AceEditor;

--- a/electron.vite.config.mjs
+++ b/electron.vite.config.mjs
@@ -13,7 +13,10 @@ export default defineConfig({
       },
       rollupOptions: {
         output: {
-          entryFileNames: 'main.js'
+          // Force CJS format and .cjs extension so Node/Electron treats it as
+          // CJS even though the root package.json declares "type": "module".
+          format: 'cjs',
+          entryFileNames: 'main.cjs'
         }
       }
     }
@@ -26,8 +29,11 @@ export default defineConfig({
       },
       rollupOptions: {
         output: {
-          // Preload must be CommonJS (sandbox-friendly) — keep the .js name.
-          entryFileNames: 'preload.js'
+          // Preload must be CommonJS (sandbox-friendly) — force CJS format and
+          // use .cjs extension so Node/Electron treats it as CJS even though the
+          // root package.json declares "type": "module".
+          format: 'cjs',
+          entryFileNames: 'preload.cjs'
         }
       }
     }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -481,7 +481,7 @@ function createWindow(): void {
     width: 1024,
     height: 728,
     webPreferences: {
-      preload: path.join(__dirname, '../preload/preload.js'),
+      preload: path.join(__dirname, '../preload/preload.cjs'),
       contextIsolation: true,
       nodeIntegration: false,
       sandbox: true

--- a/harness/e2e/electronE2e.test.js
+++ b/harness/e2e/electronE2e.test.js
@@ -1,7 +1,7 @@
 // End-to-end test of the REAL built Keypunch app driven through Playwright's
 // `_electron` driver, against the in-process mock z/OS FTP/JES server.
 //
-// It launches the packaged build (out/main/main.js, the root package.json
+// It launches the packaged build (out/main/main.cjs, the root package.json
 // `main`), with all FTP I/O really happening in the main process over a TCP
 // socket to the mock server. The renderer only talks to main through the
 // `window.keypunch` preload bridge.

--- a/harness/launch-smoke.js
+++ b/harness/launch-smoke.js
@@ -1,5 +1,5 @@
 // Minimal automated *boot* smoke for the built app: launch the real Electron
-// binary against the electron-vite build output (out/main/main.js, referenced
+// binary against the electron-vite build output (out/main/main.cjs, referenced
 // by the root package.json `main`) and assert it starts and stays up — i.e. the
 // main process, preload, and renderer bundle load without a fatal error — then
 // terminate.
@@ -15,7 +15,7 @@ import { existsSync } from 'fs';
 
 const electronExe = fileURLToPath(new URL('../node_modules/electron/dist/electron.exe', import.meta.url));
 const repoRoot = fileURLToPath(new URL('../', import.meta.url));
-const builtMain = fileURLToPath(new URL('../out/main/main.js', import.meta.url));
+const builtMain = fileURLToPath(new URL('../out/main/main.cjs', import.meta.url));
 const UPTIME_MS = Number(process.env.SMOKE_UPTIME_MS || 8000);
 
 if (!existsSync(electronExe)) {
@@ -23,7 +23,7 @@ if (!existsSync(electronExe)) {
   process.exit(1);
 }
 if (!existsSync(builtMain)) {
-  console.error('FAIL: out/main/main.js not found — run `npm run build` first.');
+  console.error('FAIL: out/main/main.cjs not found — run `npm run build` first.');
   process.exit(1);
 }
 

--- a/harness/playwright.config.js
+++ b/harness/playwright.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 // Playwright config for the Electron end-to-end test. The e2e launches the
-// REAL built app (out/main/main.js) via Playwright's `_electron` driver and
+// REAL built app (out/main/main.cjs) via Playwright's `_electron` driver and
 // drives the UI against the in-process mock JES server. No browser download is
 // needed — `_electron.launch` uses the app's own Electron binary.
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "productName": "Keypunch",
   "version": "0.1.0",
   "description": "Lightweight text editor designed to accelerate the ease of learning core IBM Mainframe languages like COBOL, PL/I, or z/Architecture Assembler by providing a dynamic hot reloading experience similar to Code School or Codecademy.",
-  "main": "out/main/main.js",
+  "type": "module",
+  "main": "out/main/main.cjs",
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",


### PR DESCRIPTION
## Summary

Closes #71.

Adds `"type": "module"` to `package.json` so Node.js treats `.js` files as ESM by default. Three companion changes make it work end-to-end:

- **Main & preload bundles forced to CJS** — electron-vite's rollup output for `main` and `preload` is set to `format: 'cjs'` with `.cjs` extensions. Node/Electron will always load `.cjs` files as CommonJS regardless of the package type, which is required for Electron's main process and sandbox-mode preload.
- **`package.json` `main` updated** — points to `out/main/main.cjs` (was `main.js`).
- **react-ace interop shim** (`app/utils/react-ace.ts`) — with `"type": "module"`, rollup applies `isNodeMode=1` semantics in `__toESM()`, which ignores the `__esModule: true` convention used by CJS-compiled packages. For `react-ace`, this caused the default import to resolve to the whole `module.exports` object instead of the component class, triggering React error #130. The shim detects and unwraps this case so all three components (`Editor`, `Explorer`, `Results`) receive the correct class reference.

## What changed

| File | Change |
|---|---|
| `package.json` | Added `"type": "module"`, updated `main` → `out/main/main.cjs` |
| `electron.vite.config.mjs` | Added `format: 'cjs'` + `entryFileNames: '*.cjs'` for main & preload outputs |
| `electron/main.ts` | Preload path updated to `preload.cjs` |
| `app/utils/react-ace.ts` | New interop shim for react-ace CJS default export |
| `app/components/{Editor,Explorer,Results}.tsx` | Import from shim instead of `'react-ace'` directly |
| `.github/workflows/ci.yml` | Build artifact assertion updated for `.cjs` filenames |
| `harness/` (3 files) | Comment/path references updated for `main.cjs` |

## Test plan

- [x] `npm run typecheck` — passes clean
- [x] `npm run lint` — passes clean
- [x] `npm run build` — all three outputs produced (`out/main/main.cjs`, `out/preload/preload.cjs`, `out/renderer/index.html`)
- [x] Bundle analysis confirms shim detection logic compiled in: `var AceEditor = isWrapped(mod) ? mod.default : mod`
- [ ] CI: lint / typecheck / harness-tests / build / e2e jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)