### PR TITLE
chore: remove unused lodash dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@reduxjs/toolkit": "^2.9.0",
         "ace-builds": "^1.43.0",
-        "lodash": "^4.17.21",
         "promise-ftp": "^1.3.2",
         "react": "^19.2.7",
         "react-ace": "^14.0.1",
@@ -21,7 +20,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
-        "@types/lodash": "^4.17.24",
         "@types/node": "^22.10.0",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
@@ -1605,13 +1603,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/lodash": {
-      "version": "4.17.24",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.24.tgz",
-      "integrity": "sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -6295,6 +6286,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.get": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "homepage": "https://github.com/bushidocodes/keypunch#readme",
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@types/lodash": "^4.17.24",
     "@types/node": "^22.10.0",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
@@ -98,7 +97,6 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.9.0",
     "ace-builds": "^1.43.0",
-    "lodash": "^4.17.21",
     "promise-ftp": "^1.3.2",
     "react": "^19.2.7",
     "react-ace": "^14.0.1",


### PR DESCRIPTION
## Summary

- `lodash` (`^4.17.21`) and `@types/lodash` (`^4.17.24`) are declared in `package.json` but never imported anywhere in the source tree (`app/`, `electron/`, `harness/`)
- Neither package appears in the built renderer bundle or main process output
- Removing them reduces the install footprint with no functional change

## Verification

```
grep -rn "lodash" app/ electron/ harness/   # → no matches
```

Typecheck, lint, and production build all pass after removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)