### PR TITLE
build(deps): upgrade TypeScript 5.9 → 6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.6.0",
-        "typescript": "^5.7.2",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.61.0",
         "vite": "^8.0.16"
       }
@@ -8234,9 +8234,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.6.0",
-    "typescript": "^5.7.2",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.61.0",
     "vite": "^8.0.16"
   },


### PR DESCRIPTION
## Summary

Bumps `typescript` from `^5.7.2` to `^6.0.3` (latest stable).

This turned out to be a zero-friction upgrade:
- `tsc --noEmit` → **0 errors**
- `electron-vite build` → clean
- `eslint .` (via `typescript-eslint`) → clean

The existing `tsconfig.json` already uses settings that align with TS 6 defaults — `moduleResolution: bundler`, `strict: true`, `skipLibCheck: true`, `esModuleInterop: true` — so no config changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)