### PR TITLE
chore: remove stale esbuild@0.27.7 allowScripts entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,6 @@
   },
   "allowScripts": {
     "electron-winstaller@5.4.0": true,
-    "esbuild@0.25.12": true,
-    "esbuild@0.27.7": true
+    "esbuild@0.25.12": true
   }
 }


### PR DESCRIPTION
The `allowScripts` field in `package.json` had an entry for `esbuild@0.27.7` that is no longer present in the dependency tree. The version actually installed (via `electron-vite`) is `0.25.12`, which already has its own entry. Removing the dead entry.

The remaining HIGH audit on `esbuild <=0.28.0` (via `electron-vite`) is unfixable without a stable `electron-vite` v6 release — `npm audit fix --force` would downgrade to `electron-vite@1.0.20`, breaking the Vite 8 requirement. This is documented in `CLAUDE.md` under "Dependency notes".

🤖 Generated with [Claude Code](https://claude.com/claude-code)