### PR TITLE
chore: fix stale esbuild@0.21.5 allowScripts entry in harness

### DIFF
--- a/harness/package.json
+++ b/harness/package.json
@@ -21,7 +21,7 @@
     "vitest": "^3.2.6"
   },
   "allowScripts": {
-    "esbuild@0.21.5": true
+    "esbuild@0.27.7": true
   },
   "dependencies": {
     "basic-ftp": "^6.0.1"


### PR DESCRIPTION
Installed esbuild version in `harness/` is `0.27.7` (pulled in by vitest); the `allowScripts` entry still referenced `0.21.5` from an earlier dependency state.

Mirrors the same stale-entry cleanup done for the root `package.json` in #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)