### PR TITLE
Tighten TypeScript strictness across the codebase

### DIFF
--- a/app/components/Results.tsx
+++ b/app/components/Results.tsx
@@ -61,7 +61,7 @@ function Results(props: Props) {
   const activeJobID: string | null =
     selectedJobID && props.jobs[selectedJobID]
       ? selectedJobID
-      : (jobIDs.length > 0 ? jobIDs[0] : null);
+      : (jobIDs[0] ?? null);
 
   if (jobIDs.length === 0) {
     return (
@@ -73,7 +73,7 @@ function Results(props: Props) {
     );
   }
 
-  const activeJob: JobEntry | null = activeJobID ? props.jobs[activeJobID] : null;
+  const activeJob: JobEntry | null = activeJobID ? (props.jobs[activeJobID] ?? null) : null;
 
   return (
     <div className="results">

--- a/app/components/StatusBar.tsx
+++ b/app/components/StatusBar.tsx
@@ -63,23 +63,20 @@ function StatusBar(props: Props) {
         </button>
       )}
 
-      {(['CONN', 'SENT', 'RETR', 'DISC'] as const).map((label, i) => {
-        const [isLit, isBlinking] = [
-          [props.isConnected,    props.isConnecting],
-          [props.isSubmitted,    props.isSubmitting],
-          [props.isRetrieved,    props.isRetrieving],
-          [props.isDisconnected, props.isDisconnecting],
-        ][i];
-        return (
-          <div key={label} className="indicator-cell">
-            {label}
-            <br />
-            <div className="indicator-light">
-              <Indicator isLit={isLit} isBlinking={isBlinking} />
-            </div>
+      {[
+        { label: 'CONN', isLit: props.isConnected,    isBlinking: props.isConnecting },
+        { label: 'SENT', isLit: props.isSubmitted,    isBlinking: props.isSubmitting },
+        { label: 'RETR', isLit: props.isRetrieved,    isBlinking: props.isRetrieving },
+        { label: 'DISC', isLit: props.isDisconnected, isBlinking: props.isDisconnecting },
+      ].map(({ label, isLit, isBlinking }) => (
+        <div key={label} className="indicator-cell">
+          {label}
+          <br />
+          <div className="indicator-light">
+            <Indicator isLit={isLit} isBlinking={isBlinking} />
           </div>
-        );
-      })}
+        </div>
+      ))}
 
       <button className="btn-load" onClick={props.submitJob}>
         LOAD

--- a/app/reducers/jobs.ts
+++ b/app/reducers/jobs.ts
@@ -1,5 +1,5 @@
 import { REFRESH_JOBS, LOAD_JOB_RESULTS } from '../constants';
-import type { Job, JobMap } from '../utils/jesParse';
+import type { Job } from '../utils/jesParse';
 import type { JobsAction } from '../actions/jobs';
 
 // State is a hashmap keyed by job ID. Each value is a Job record enriched with
@@ -18,20 +18,21 @@ export default function jobs(
       // Replace the jobs state with the incoming snapshot so stale jobs
       // (deleted on the server) are removed, while preserving any downloaded
       // results for jobs that are still present in the queue.
-      const incoming = action.jobsState as JobMap;
+      const incoming = action.jobsState;
       const next: JobsState = {};
       for (const [id, job] of Object.entries(incoming)) {
         const existingResults = state[id]?.results;
         next[id] = existingResults !== undefined
-          ? { ...(job as Job), results: existingResults }
-          : { ...(job as Job) };
+          ? { ...job, results: existingResults }
+          : { ...job };
       }
       return next;
     }
     case LOAD_JOB_RESULTS: {
       const updated = { ...state };
-      if (updated[action.jobID]) {
-        updated[action.jobID] = { ...updated[action.jobID], results: action.results };
+      const existing = updated[action.jobID];
+      if (existing) {
+        updated[action.jobID] = { ...existing, results: action.results };
       }
       return updated;
     }

--- a/app/store/configureStore.ts
+++ b/app/store/configureStore.ts
@@ -10,12 +10,16 @@
 // the Phase-4 refresh (it added a CJS/ESM-interop wrinkle for no real benefit).
 import { configureStore as rtkConfigureStore } from '@reduxjs/toolkit';
 import rootReducer from '../reducers';
+import type { RootState } from '../reducers';
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export default function configureStore(preloadedState?: any) {
+export default function configureStore(preloadedState?: Partial<RootState>) {
   const store = rtkConfigureStore({
     reducer: rootReducer,
-    preloadedState,
+    // RTK collapses each slice's PreloadedState to `never` for these
+    // default-param reducers, so it won't accept a typed partial directly. The
+    // public param above keeps callers honest; this cast bridges to RTK's type.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    preloadedState: preloadedState as any,
     middleware: (getDefaultMiddleware) =>
       getDefaultMiddleware({
         immutableCheck: false,
@@ -25,6 +29,9 @@ export default function configureStore(preloadedState?: any) {
   });
 
   if (import.meta.hot) {
+    // HMR-only (dev): the new module's default reducer carries a different
+    // PreloadedState generic than the store was created with, so `any` is the
+    // pragmatic bridge here.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     import.meta.hot.accept('../reducers', (mod: any) => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/app/utils/jesParse.ts
+++ b/app/utils/jesParse.ts
@@ -81,11 +81,11 @@ export function parseJobs(results: string[] | null | undefined): JobMap {
   const jobs: JobMap = {};
   results.forEach((job) => {
     const jobSplit = job.trim().split(/ +/);
-    const jobID = jobSplit[1];
+    const jobID = jobSplit[1] ?? '';
     jobs[jobID] = {
-      owner: jobSplit[0],
-      status: jobSplit[2],
-      numberOfSpoolFiles: job.includes('Spool Files') ? jobSplit[3] : null,
+      owner: jobSplit[0] ?? '',
+      status: jobSplit[2] ?? '',
+      numberOfSpoolFiles: job.includes('Spool Files') ? (jobSplit[3] ?? null) : null,
       jobID,
       fullString: job.trim()
     };
@@ -104,7 +104,11 @@ export function parseDatasets(results: string[] | null | undefined): Dataset[] {
   const rows = results.slice(1); // drop the header row
   return rows.map((dataset) => {
     const datasetSplit = dataset.trim().split(/ +/);
-    const [volume, unit, referred, ext, used, recfm, lrecl, blksz, dsorg, dsname] = datasetSplit;
+    // Destructuring defaults cover short/ragged rows (mirrors parseMembers' `|| ''`).
+    const [
+      volume = '', unit = '', referred = '', ext = '', used = '',
+      recfm = '', lrecl = '', blksz = '', dsorg = '', dsname = ''
+    ] = datasetSplit;
     return {
       name: dsname,
       toggled: false,

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -281,7 +281,7 @@ function registerIpc(): void {
       properties: ['openFile', 'createDirectory', 'showHiddenFiles']
     });
     if (result.canceled || !result.filePaths.length) return null;
-    const filePath = result.filePaths[0];
+    const filePath = result.filePaths[0]!; // length checked above
     const content = await readFile(filePath, 'utf8');
     return { path: filePath, content };
   });
@@ -465,7 +465,8 @@ function buildMenu(): void {
         { role: 'quit' }
       ]
     });
-    (template[1].submenu as MenuItemConstructorOptions[]).push(
+    // template[1] exists: built with 4 items above, then unshift added one more.
+    (template[1]!.submenu as MenuItemConstructorOptions[]).push(
       { type: 'separator' },
       {
         label: 'Speech',

--- a/harness/tsconfig.json
+++ b/harness/tsconfig.json
@@ -10,6 +10,10 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
+    // Tests do a lot of `arr[0].foo` / `record[key]` indexing where the shape is
+    // known from the fixture; the `undefined` the root's noUncheckedIndexedAccess
+    // would add is just noise here, so relax it for the harness.
+    "noUncheckedIndexedAccess": false,
     // `types` replaces (does not merge with) the root's, so re-list "node" and
     // add vitest's globals (describe / it / expect / vi …). The jest-dom
     // matchers (toBeInTheDocument, …) are pulled in by the

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,25 @@
 {
-  // Incremental TypeScript adoption for this electron-vite + React 18 app.
-  //
-  // `allowJs` lets the still-untyped `.js` sources (the React components, redux
-  // store, etc.) coexist with the handful of files we've converted to `.ts`.
-  // `checkJs` is OFF on purpose: we only type-check the `.ts` files for now so
-  // we don't drown in errors from legacy JS. A future phase can flip it on.
+  // electron-vite + React 19 app — now 100% TypeScript.
   //
   // esbuild/Vite do the actual transpile; tsc here is type-checking only
   // (`noEmit`). `moduleResolution: bundler` matches how Vite resolves imports
   // (extensionless, no need for `.js` specifiers in TS).
+  //
+  // `strict` plus the extra `no*` flags below are the strictness baseline for
+  // shipped code: indexed access is checked for `undefined`, switch fall-through
+  // and missing returns are errors, etc. The harness (harness/tsconfig.json)
+  // extends this but relaxes `noUncheckedIndexedAccess` for terser test code.
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "allowJs": true,
-    "checkJs": false,
     "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
     "noEmit": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Follow-up to #90 (the JS→TS conversion). Now that the repo is 100% TypeScript, this enables additional strict compiler flags and removes the looseness they surface.

## tsconfig

- Dropped `allowJs` / `checkJs` — zero JS sources remain, so the escape hatch is pointless. Refreshed the stale comments (it still said "React 18 / incremental adoption / still-untyped .js sources").
- Enabled `noUncheckedIndexedAccess`, `noFallthroughCasesInSwitch`, `noImplicitOverride`, `noImplicitReturns`.
- `harness/tsconfig.json` opts out of `noUncheckedIndexedAccess` only — test code is intentionally index-heavy (`arr[0].foo`, `record[key]`) where the shape is known from the fixture, so the added `undefined` is just noise there. Strict indexing stays on for shipped code.

## Undefined-handling gaps fixed (surfaced by `noUncheckedIndexedAccess`)

- **[jesParse.ts](app/utils/jesParse.ts)** — undefined-safe row parsing: `?? ''` fallbacks in `parseJobs` and destructuring defaults in `parseDatasets`, so a short/ragged FTP `LIST` row can't produce `undefined` fields (mirrors `parseMembers`' existing `|| ''`).
- **[Results.tsx](app/components/Results.tsx)** — guard the job-selection indexing (`?? null`).
- **[StatusBar.tsx](app/components/StatusBar.tsx)** — replaced a fragile parallel-array-zipped-by-index with a self-describing object array, removing the unchecked index entirely.
- **[main.ts](electron/main.ts)** — assert `filePaths[0]` / `template[1]` right after the guards that establish them.

## Loose casts removed

- **[jobs.ts](app/reducers/jobs.ts)** — dropped redundant `as JobMap` / `as Job` (the typed `JobsAction` already narrows `action.jobsState`) and captured the entry in a `const` so the merge narrows honestly.
- **[configureStore.ts](app/store/configureStore.ts)** — typed the public `preloadedState` param as `Partial<RootState>` instead of `any`, so callers are now checked. (One documented `as any` remains for RTK's `never`-collapsed `PreloadedState`, plus the dev-only HMR block — both unavoidable with hand-written reducers.)

## Verification (all green, local)

| Check | Result |
|---|---|
| root typecheck (4 new strict flags) | ✅ |
| root lint / build | ✅ |
| harness typecheck | ✅ |
| vitest | ✅ 125/125 |
| Playwright `_electron` e2e | ✅ 2/2 |

## Note

While adding the `template[1]` assertion I noticed a likely pre-existing macOS-only menu bug (the **Speech** submenu is appended to **File** instead of **Edit**, because it's pushed after an `unshift` shifts the indices). Left as-is here to keep this a behavior-preserving type pass; worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)