### PR TITLE
Fix macOS Speech submenu added to File menu instead of Edit

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -465,14 +465,19 @@ function buildMenu(): void {
         { role: 'quit' }
       ]
     });
-    // template[1] exists: built with 4 items above, then unshift added one more.
-    (template[1]!.submenu as MenuItemConstructorOptions[]).push(
-      { type: 'separator' },
-      {
-        label: 'Speech',
-        submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }]
-      }
-    );
+    // Add the macOS Speech submenu to the Edit menu. Find it by label rather
+    // than index: the unshift above shifted every position, and the previous
+    // hardcoded index (template[1]) pointed Speech at the File menu by mistake.
+    const editMenu = template.find((item) => item.label === 'Edit');
+    if (editMenu) {
+      (editMenu.submenu as MenuItemConstructorOptions[]).push(
+        { type: 'separator' },
+        {
+          label: 'Speech',
+          submenu: [{ role: 'startSpeaking' }, { role: 'stopSpeaking' }]
+        }
+      );
+    }
   }
 
   Menu.setApplicationMenu(Menu.buildFromTemplate(template));


### PR DESCRIPTION
Closes #92.

## Problem

In `buildMenu()` (`electron/main.ts`), the macOS branch builds the base template as `[File, Edit, View, help]`, then prepends the application menu:

```ts
template.unshift({ label: app.name, submenu: [ /* app menu */ ] });
// template is now [appMenu, File, Edit, View, help]
(template[1].submenu as MenuItemConstructorOptions[]).push(/* Speech */);
```

After the `unshift`, `template[1]` is the **File** menu (Edit moved to index 2), so the **Speech** submenu (Start/Stop Speaking) was appended to **File** instead of **Edit**.

## Fix

Locate the Edit menu by label rather than a position that the `unshift` invalidates:

```ts
const editMenu = template.find((item) => item.label === 'Edit');
if (editMenu) {
  (editMenu.submenu as MenuItemConstructorOptions[]).push(/* Speech */);
}
```

This is robust to the `unshift` and to any future reordering of the base template.

## Verification

`npm run typecheck`, `npm run lint`, `npm run build`, and the boot smoke (`npm run smoke`) all pass.

⚠️ The macOS menu placement itself can't be exercised on this machine or in CI — the affected code is inside `if (process.platform === 'darwin')`, and CI/e2e run on Linux/Windows. The fix is verified by typecheck/build + inspection; a maintainer on macOS can confirm Speech now appears under Edit.

## Note

Touches the same `buildMenu` darwin block as #91 (which added a `template[1]!` non-null assertion). Whichever merges second will need a trivial rebase of that block — this PR removes the `template[1]` access entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)