### PR TITLE
ci: add workflow-level permissions to fix CodeQL alerts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint (ESLint)

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -10,6 +10,9 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   package:
     name: Package (${{ matrix.os }})


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` at the top level of both `.github/workflows/ci.yml` and `.github/workflows/package.yml`
- Resolves 6 CodeQL "Workflow does not contain permissions" alerts (#1, #4, #12, #13, #14, #15)

## What changed and why

GitHub's CodeQL security scanner flags workflows that don't declare explicit permissions, because without them the `GITHUB_TOKEN` defaults to broad write access. Adding `permissions: contents: read` at the workflow level locks the token down to the minimum required — read-only repository access — for all jobs. No per-job overrides are needed since no job writes back to the repo, packages a release token, or interacts with the GitHub API beyond artifact upload (which uses the Actions runtime token, not `GITHUB_TOKEN`).

## Reviewer notes

- This is a pure CI security hardening change — no runtime behavior is altered
- If a future job ever needs write access (e.g. publishing a release), add a job-level `permissions` block to grant only what that job needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)