### PR TITLE
Add Dependabot cooldown (default-days: 3)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,12 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
 ---


### PR DESCRIPTION
## Summary
- Adds a `cooldown: { default-days: 3 }` block to both `updates` entries in `.github/dependabot.yml` (github-actions and npm ecosystems), so Dependabot waits 3 days after a release before opening a version-bump PR.

Closes #107

This also would have avoided the CI failure seen on #102, where pnpm's `minimumReleaseAge` supply-chain policy rejected `tsx@4.23.0` because Dependabot opened the PR only hours after the release shipped.

## Test plan
- [x] `.github/dependabot.yml` is valid YAML (structure unchanged aside from the new `cooldown` keys)
- [ ] Confirm on GitHub that the Dependabot config validates (Insights → Dependency graph → Dependabot, or wait for the next scheduled run)